### PR TITLE
Training results: result_no_fp

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -53,7 +53,7 @@ stages:
     - uv run python ./scripts/data/model_input/build.py --input-dir 
       ./data/01_model_input/yolo_train_val --output-dir 
       ./data/01_model_input/yolo_train_val_small --sampling-ratio 1 
-      --random-seed 0 --loglevel info
+      --random-seed 0 --remove-background --loglevel info
     - uv run python ./scripts/model/yolo/train.py --data 
       ./data/01_model_input/yolo_train_val_small/datasets/data.yaml --config 
       ./scripts/model/yolo/configs/best.yaml --output-dir ./data/02_models/yolo/
@@ -66,8 +66,8 @@ stages:
       nfiles: 30387
     - path: ./scripts/data/model_input/build.py
       hash: md5
-      md5: 7607af10f59267cf9859cb1d372aff26
-      size: 6432
+      md5: 90d0643f57bff22e2005b43e33eca658
+      size: 7200
     - path: ./scripts/model/yolo/configs/best.yaml
       hash: md5
       md5: 82ab9c26b11cfc5f72e1398bfceeb838
@@ -79,8 +79,8 @@ stages:
     outs:
     - path: ./data/02_models/yolo/best
       hash: md5
-      md5: be5d61086d3a2b2e68e8a5dd61b14901.dir
-      size: 44003643
+      md5: ef33a081ba731d593ab9a0fe4800dce6.dir
+      size: 44144497
       nfiles: 24
   build_manifest_yolo_best:
     cmd:
@@ -90,8 +90,8 @@ stages:
     deps:
     - path: ./data/02_models/yolo/best/
       hash: md5
-      md5: be5d61086d3a2b2e68e8a5dd61b14901.dir
-      size: 44003643
+      md5: ef33a081ba731d593ab9a0fe4800dce6.dir
+      size: 44144497
       nfiles: 24
     - path: ./scripts/model/yolo/build_manifest.py
       hash: md5
@@ -100,8 +100,8 @@ stages:
     outs:
     - path: ./data/03_reporting/yolo/best/
       hash: md5
-      md5: d16e4d5660095fd5a38280ebea098ddc.dir
-      size: 13490
+      md5: 59f4049af600621c0844149d64d2c4b6.dir
+      size: 13509
       nfiles: 1
   export_yolo_best@onnx-cpu:
     cmd:
@@ -111,8 +111,8 @@ stages:
     deps:
     - path: ./data/02_models/yolo/best/
       hash: md5
-      md5: be5d61086d3a2b2e68e8a5dd61b14901.dir
-      size: 44003643
+      md5: ef33a081ba731d593ab9a0fe4800dce6.dir
+      size: 44144497
       nfiles: 24
     - path: ./scripts/model/yolo/export.py
       hash: md5
@@ -121,8 +121,8 @@ stages:
     outs:
     - path: ./data/02_models/yolo-export/best/onnx/cpu
       hash: md5
-      md5: 0b4f67d18810a40cb4d783312a4bdca8.dir
-      size: 38512704
+      md5: 76c2657924bd0cbaa9b51af740cbb2a9.dir
+      size: 38110171
       nfiles: 1
   export_yolo_best@onnx-mps:
     cmd:
@@ -153,8 +153,8 @@ stages:
     deps:
     - path: ./data/02_models/yolo/best/
       hash: md5
-      md5: be5d61086d3a2b2e68e8a5dd61b14901.dir
-      size: 44003643
+      md5: ef33a081ba731d593ab9a0fe4800dce6.dir
+      size: 44144497
       nfiles: 24
     - path: ./scripts/model/yolo/export.py
       hash: md5
@@ -163,7 +163,7 @@ stages:
     outs:
     - path: ./data/02_models/yolo-export/best/ncnn/cpu
       hash: md5
-      md5: e1493ed19c061ad3ec6b00caead444bd.dir
+      md5: 0f8355b8f51cec18893b3ef42fdf5782.dir
       size: 38001888
       nfiles: 5
   export_yolo_best@ncnn-mps:
@@ -256,7 +256,7 @@ stages:
       nfiles: 12448
     - path: ./data/02_models/yolo/best/weights/best.pt
       hash: md5
-      md5: fea4ddc8d904fcc5ff11ad900e040837
+      md5: 16245b87d38a7516ee88f22c2defbae0
       size: 19225626
     - path: predict_sequential.py
       hash: md5
@@ -265,8 +265,8 @@ stages:
     outs:
     - path: ./data/03_reporting/sequential/predictions_labels_val
       hash: md5
-      md5: cbe0e8e4d58627ca6856371246d400c2.dir
-      size: 104904
+      md5: b4a46192f622cdcd95132339899550ff.dir
+      size: 140342
       nfiles: 3438
   optimize_sequential_val:
     cmd:
@@ -277,8 +277,8 @@ stages:
     deps:
     - path: ./data/03_reporting/sequential/predictions_labels_val
       hash: md5
-      md5: cbe0e8e4d58627ca6856371246d400c2.dir
-      size: 104904
+      md5: b4a46192f622cdcd95132339899550ff.dir
+      size: 140342
       nfiles: 3438
     - path: optimize_sequential.py
       hash: md5
@@ -287,9 +287,9 @@ stages:
     outs:
     - path: ./data/03_reporting/sequential/grid_search_val.tsv
       hash: md5
-      md5: 8bae210202dc4210162712779346d572
-      size: 1896
+      md5: 43e5bb3b8110c832cb6f50d4ea0bf5dc
+      size: 1904
     - path: ./data/03_reporting/sequential/grid_search_val_top20.tsv
       hash: md5
-      md5: 42f461234b5a48ca27bb28a46afb2cd0
-      size: 975
+      md5: 2e7cb133e0e69e4f9131e2e9716521ab
+      size: 984

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -20,6 +20,7 @@ stages:
       --output-dir ./data/01_model_input/yolo_train_val_small
       --sampling-ratio 1
       --random-seed 0
+      --remove-background
       --loglevel info
     - >-
       uv run python ./scripts/model/yolo/train.py

--- a/results/eval_results.json
+++ b/results/eval_results.json
@@ -1,8 +1,8 @@
 {
-  "precision": 0.788629074749298,
-  "recall": 0.7360742705570292,
-  "map50": 0.7555552278085748,
-  "map50_95": 0.4801768125555643,
+  "precision": 0.7019861445113841,
+  "recall": 0.6909814323607427,
+  "map50": 0.6682582900023558,
+  "map50_95": 0.4270727791359863,
   "model_dir": "data/02_models/yolo/best",
   "data": "data/test/yolo_test/data.yaml",
   "split": "test"

--- a/results/eval_sequential_results.json
+++ b/results/eval_sequential_results.json
@@ -1,12 +1,12 @@
 {
-  "nb_consecutive_frames": 4,
-  "conf_thresh": 0.2,
-  "tp": 143,
-  "fn": 6,
-  "fp": 21,
-  "tn": 128,
-  "recall": 0.9597,
-  "fpr": 0.1409,
-  "precision": 0.872,
-  "f1": 0.9137
+  "nb_consecutive_frames": 8,
+  "conf_thresh": 0.4,
+  "tp": 113,
+  "fn": 4,
+  "fp": 12,
+  "tn": 111,
+  "recall": 0.9658,
+  "fpr": 0.0976,
+  "precision": 0.904,
+  "f1": 0.9339
 }

--- a/scripts/data/model_input/build.py
+++ b/scripts/data/model_input/build.py
@@ -42,6 +42,12 @@ def make_cli_parser() -> argparse.ArgumentParser:
         type=int,
     )
     parser.add_argument(
+        "--remove-background",
+        help="Remove background (negative) images that have empty label files",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
         "-log",
         "--loglevel",
         default="warning",
@@ -116,6 +122,7 @@ def sample_dataset(
     output_dir: Path,
     sampling_ratio: float = 0.1,
     random_seed: int = 0,
+    remove_background: bool = False,
 ) -> list[dict]:
     """
     Return a downsampled list of images and labels for the given
@@ -140,6 +147,15 @@ def sample_dataset(
             downsampled_image_filepaths = random.Random(random_seed).sample(
                 images_filepaths,
                 k=k,
+            )
+        if remove_background:
+            downsampled_image_filepaths = [
+                fp for fp in downsampled_image_filepaths
+                if (labels_split_dir / f"{fp.stem}.txt").exists()
+                and (labels_split_dir / f"{fp.stem}.txt").stat().st_size > 0
+            ]
+            logging.info(
+                f"[{split}] Removed background images. Remaining: {len(downsampled_image_filepaths)}"
             )
         downsampled_label_filepaths = [
             labels_split_dir / f"{fp.stem}.txt"
@@ -190,6 +206,7 @@ if __name__ == "__main__":
         output_dir = args["output_dir"]
         sampling_ratio = args["sampling_ratio"]
         random_seed = args["random_seed"]
+        remove_background = args["remove_background"]
 
         logging.info(f"Creating dirs at {output_dir}")
         shutil.rmtree(output_dir, ignore_errors=True)
@@ -202,6 +219,7 @@ if __name__ == "__main__":
                 output_dir=output_dir / "datasets",
                 sampling_ratio=sampling_ratio,
                 random_seed=random_seed,
+                remove_background=remove_background,
             )
         )
         write_data_yaml(output_dir / "datasets" / "data.yaml")


### PR DESCRIPTION
## Evaluation results on test set

| Metric | main | current | Δ |
|--------|------|---------|---|
| mAP@50 | 0.7556 | 0.6683 | -0.0873 |
| mAP@50-95 | 0.4802 | 0.4271 | -0.0531 |
| Precision | 0.7886 | 0.7020 | -0.0866 |
| Recall | 0.7361 | 0.6910 | -0.0451 |

## Sequential evaluation on test (optimized params: nb_frames=8, conf=0.4)

TP=113 FN=4 FP=12 TN=111

| Metric | main | current | Δ |
|--------|------|---------|---|
| Recall (TP rate) | 0.9597 | 0.9658 | +0.0061 |
| FPR | 0.1409 | 0.0976 | -0.0433 |
| F1 | 0.9137 | 0.9339 | +0.0202 |
| Precision | 0.8720 | 0.9040 | +0.0320 |

## Engine parameter optimization (top 10 on val)

| nb_frames | conf | TP | FN | FP | TN | Recall | FPR | F1 |
|-----------|------|----|----|----|----|--------|-----|----|
| 8 | 0.4 | 90 | 13 | 11 | 113 | 0.8738 | 0.0887 | 0.8824 |
| 7 | 0.4 | 91 | 12 | 17 | 107 | 0.8835 | 0.1371 | 0.8626 |
| 8 | 0.35 | 93 | 10 | 20 | 104 | 0.9029 | 0.1613 | 0.8611 |
| 6 | 0.35 | 94 | 9 | 24 | 100 | 0.9126 | 0.1935 | 0.8507 |
| 7 | 0.35 | 94 | 9 | 24 | 100 | 0.9126 | 0.1935 | 0.8507 |
| 8 | 0.2 | 98 | 5 | 30 | 94 | 0.9515 | 0.2419 | 0.8485 |
| 5 | 0.35 | 95 | 8 | 26 | 98 | 0.9223 | 0.2097 | 0.8482 |
| 8 | 0.3 | 95 | 8 | 26 | 98 | 0.9223 | 0.2097 | 0.8482 |
| 6 | 0.4 | 91 | 12 | 21 | 103 | 0.8835 | 0.1694 | 0.8465 |
| 8 | 0.25 | 96 | 7 | 28 | 96 | 0.932 | 0.2258 | 0.8458 |

_(vs last committed results on main)_
**Branch:** `result_no_fp` | **Test dataset:** pyronear/pyro-dataset @ v2.1.0