### PR TITLE
Training results: result_4.0.0-nobackground

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -53,7 +53,7 @@ stages:
     - uv run python ./scripts/data/model_input/build.py --input-dir 
       ./data/01_model_input/yolo_train_val --output-dir 
       ./data/01_model_input/yolo_train_val_small --sampling-ratio 1 
-      --random-seed 0 --loglevel info
+      --random-seed 0 --exclude-background --loglevel info
     - uv run python ./scripts/model/yolo/train.py --data 
       ./data/01_model_input/yolo_train_val_small/datasets/data.yaml --config 
       ./scripts/model/yolo/configs/best.yaml --output-dir ./data/02_models/yolo/
@@ -66,8 +66,8 @@ stages:
       nfiles: 32201
     - path: ./scripts/data/model_input/build.py
       hash: md5
-      md5: 7607af10f59267cf9859cb1d372aff26
-      size: 6432
+      md5: f745456171e8a8b24faca0e5f2bc0a22
+      size: 7800
     - path: ./scripts/model/yolo/configs/best.yaml
       hash: md5
       md5: 82ab9c26b11cfc5f72e1398bfceeb838
@@ -79,8 +79,8 @@ stages:
     outs:
     - path: ./data/02_models/yolo/best
       hash: md5
-      md5: 0e3617cd00b6a1985129110757bca1a0.dir
-      size: 44813862
+      md5: 52216f9194f58306d24d4802af43394a.dir
+      size: 44857368
       nfiles: 24
   build_manifest_yolo_best:
     cmd:
@@ -90,8 +90,8 @@ stages:
     deps:
     - path: ./data/02_models/yolo/best/
       hash: md5
-      md5: 0e3617cd00b6a1985129110757bca1a0.dir
-      size: 44813862
+      md5: 52216f9194f58306d24d4802af43394a.dir
+      size: 44857368
       nfiles: 24
     - path: ./scripts/model/yolo/build_manifest.py
       hash: md5
@@ -100,8 +100,8 @@ stages:
     outs:
     - path: ./data/03_reporting/yolo/best/
       hash: md5
-      md5: c01eb3ce79f23e0999d3220813c01881.dir
-      size: 13529
+      md5: d84534ecf412205433bb15237ab4215c.dir
+      size: 13570
       nfiles: 1
   export_yolo_best@onnx-cpu:
     cmd:
@@ -111,8 +111,8 @@ stages:
     deps:
     - path: ./data/02_models/yolo/best/
       hash: md5
-      md5: 0e3617cd00b6a1985129110757bca1a0.dir
-      size: 44813862
+      md5: 52216f9194f58306d24d4802af43394a.dir
+      size: 44857368
       nfiles: 24
     - path: ./scripts/model/yolo/export.py
       hash: md5
@@ -121,8 +121,8 @@ stages:
     outs:
     - path: ./data/02_models/yolo-export/best/onnx/cpu
       hash: md5
-      md5: 3e101e69ac72dc3109be7afd2b61aa4a.dir
-      size: 38532985
+      md5: 70dcbce65843be7b21c07b87a1638c17.dir
+      size: 38215733
       nfiles: 1
   export_yolo_best@onnx-mps:
     cmd:
@@ -153,8 +153,8 @@ stages:
     deps:
     - path: ./data/02_models/yolo/best/
       hash: md5
-      md5: 0e3617cd00b6a1985129110757bca1a0.dir
-      size: 44813862
+      md5: 52216f9194f58306d24d4802af43394a.dir
+      size: 44857368
       nfiles: 24
     - path: ./scripts/model/yolo/export.py
       hash: md5
@@ -163,7 +163,7 @@ stages:
     outs:
     - path: ./data/02_models/yolo-export/best/ncnn/cpu
       hash: md5
-      md5: f6f1f2b316198f427a51b3b8335e7b7c.dir
+      md5: eb6218fa84411a1bd8a24190d286331f.dir
       size: 38001906
       nfiles: 5
   export_yolo_best@ncnn-mps:
@@ -257,7 +257,7 @@ stages:
       nfiles: 11478
     - path: ./data/02_models/yolo/best/weights/best.pt
       hash: md5
-      md5: 550d1b91fb93e52cf233166b03405a10
+      md5: 1074afc0b91d99370d107a17b8c5b29f
       size: 19225626
     - path: predict_sequential.py
       hash: md5
@@ -266,8 +266,8 @@ stages:
     outs:
     - path: ./data/03_reporting/sequential/predictions_labels_val
       hash: md5
-      md5: 796a49a2802fa773158ca168a680f12c.dir
-      size: 109228
+      md5: 30d4cd6007438c36d3a7cc01af62cbdb.dir
+      size: 127793
       nfiles: 3340
   optimize_sequential_val:
     cmd:
@@ -278,8 +278,8 @@ stages:
     deps:
     - path: ./data/03_reporting/sequential/predictions_labels_val
       hash: md5
-      md5: 796a49a2802fa773158ca168a680f12c.dir
-      size: 109228
+      md5: 30d4cd6007438c36d3a7cc01af62cbdb.dir
+      size: 127793
       nfiles: 3340
     - path: optimize_sequential.py
       hash: md5
@@ -288,9 +288,9 @@ stages:
     outs:
     - path: ./data/03_reporting/sequential/grid_search_val.tsv
       hash: md5
-      md5: aa6f9da227c79d6ffa2903e7b9a3d18b
-      size: 1873
+      md5: 027945e7c6a9b512fbc82ed6ec721249
+      size: 1913
     - path: ./data/03_reporting/sequential/grid_search_val_top20.tsv
       hash: md5
-      md5: dd8e0aa4c8bc678deb27acbdd911c065
-      size: 973
+      md5: 933b10550f566f4e38d5f9dabe10cb9b
+      size: 1006

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -20,6 +20,7 @@ stages:
       --output-dir ./data/01_model_input/yolo_train_val_small
       --sampling-ratio 1
       --random-seed 0
+      --exclude-background
       --loglevel info
     - >-
       uv run python ./scripts/model/yolo/train.py

--- a/results/eval_results.json
+++ b/results/eval_results.json
@@ -1,8 +1,8 @@
 {
-  "precision": 0.7801831566503715,
-  "recall": 0.7129963898916968,
-  "map50": 0.7478004027603852,
-  "map50_95": 0.45667696600893326,
+  "precision": 0.70047095037678,
+  "recall": 0.7147988980963277,
+  "map50": 0.6735728102706215,
+  "map50_95": 0.4156789169357472,
   "model_dir": "data/02_models/yolo/best",
   "data": "data/test/yolo_test/data.yaml",
   "split": "test"

--- a/results/eval_sequential_results.json
+++ b/results/eval_sequential_results.json
@@ -1,12 +1,12 @@
 {
-  "nb_consecutive_frames": 4,
-  "conf_thresh": 0.25,
-  "tp": 115,
-  "fn": 4,
-  "fp": 13,
-  "tn": 97,
-  "recall": 0.9664,
-  "fpr": 0.1182,
-  "precision": 0.8984,
-  "f1": 0.9312
+  "nb_consecutive_frames": 7,
+  "conf_thresh": 0.35,
+  "tp": 114,
+  "fn": 5,
+  "fp": 18,
+  "tn": 92,
+  "recall": 0.958,
+  "fpr": 0.1636,
+  "precision": 0.8636,
+  "f1": 0.9084
 }

--- a/scripts/data/model_input/build.py
+++ b/scripts/data/model_input/build.py
@@ -42,6 +42,11 @@ def make_cli_parser() -> argparse.ArgumentParser:
         type=int,
     )
     parser.add_argument(
+        "--exclude-background",
+        help="Exclude background images (empty label files) from the train split to train an ultra-sensitive model",
+        action="store_true",
+    )
+    parser.add_argument(
         "-log",
         "--loglevel",
         default="warning",
@@ -111,11 +116,20 @@ def copy_data(input_dir: Path, output_dir: Path) -> None:
         )
 
 
+def is_background(label_filepath: Path) -> bool:
+    """
+    Return whether the given label file corresponds to a background image,
+    ie. a missing or empty label file (no smoke annotation).
+    """
+    return not label_filepath.exists() or label_filepath.stat().st_size == 0
+
+
 def sample_dataset(
     input_dir: Path,
     output_dir: Path,
     sampling_ratio: float = 0.1,
     random_seed: int = 0,
+    exclude_background: bool = False,
 ) -> list[dict]:
     """
     Return a downsampled list of images and labels for the given
@@ -124,6 +138,9 @@ def sample_dataset(
     Each element in the returned list has the following keys:
     - to: Path - where the image/label comes from
     - from: Path - where the image/label should be copied over - using the provided `output_dir`
+
+    When `exclude_background` is set, background images (empty label files)
+    are dropped from the train split to train an ultra-sensitive model.
     """
     assert 0 <= sampling_ratio <= 1.0, "sampling ratio should be between 0 and 1"
 
@@ -132,6 +149,19 @@ def sample_dataset(
         labels_split_dir = input_dir / "labels" / split
         images_split_dir = input_dir / "images" / split
         images_filepaths = list(images_split_dir.glob("*.jpg"))
+        # Drop background images (empty labels) from the train split only, so
+        # that the val split stays intact for a comparable evaluation.
+        if exclude_background and split == "train":
+            n_before = len(images_filepaths)
+            images_filepaths = [
+                fp
+                for fp in images_filepaths
+                if not is_background(labels_split_dir / f"{fp.stem}.txt")
+            ]
+            logging.info(
+                f"Excluded {n_before - len(images_filepaths)} background images "
+                f"from the {split} split ({len(images_filepaths)} remaining)"
+            )
         n_images = len(images_filepaths)
         k = int(n_images * sampling_ratio)
         # For the val split we do not subsample as we want to eval on the same data as in the full
@@ -202,6 +232,7 @@ if __name__ == "__main__":
                 output_dir=output_dir / "datasets",
                 sampling_ratio=sampling_ratio,
                 random_seed=random_seed,
+                exclude_background=args["exclude_background"],
             )
         )
         write_data_yaml(output_dir / "datasets" / "data.yaml")


### PR DESCRIPTION
## Evaluation results on test set

| Metric | main | current | Δ |
|--------|------|---------|---|
| mAP@50 | 0.7478 | 0.6736 | -0.0742 |
| mAP@50-95 | 0.4567 | 0.4157 | -0.0410 |
| Precision | 0.7802 | 0.7005 | -0.0797 |
| Recall | 0.7130 | 0.7148 | +0.0018 |

## Sequential evaluation on test (optimized params: nb_frames=7, conf=0.35)

TP=114 FN=5 FP=18 TN=92

| Metric | main | current | Δ |
|--------|------|---------|---|
| Recall (TP rate) | 0.9664 | 0.9580 | -0.0084 |
| FPR | 0.1182 | 0.1636 | +0.0454 |
| F1 | 0.9312 | 0.9084 | -0.0228 |
| Precision | 0.8984 | 0.8636 | -0.0348 |

## Engine parameter optimization (top 10 on val)

| nb_frames | conf | TP | FN | FP | TN | Recall | FPR | F1 |
|-----------|------|----|----|----|----|--------|-----|----|
| 7 | 0.35 | 100 | 11 | 11 | 100 | 0.9009 | 0.0991 | 0.9009 |
| 5 | 0.3 | 104 | 7 | 16 | 95 | 0.9369 | 0.1441 | 0.9004 |
| 6 | 0.3 | 103 | 8 | 15 | 96 | 0.9279 | 0.1351 | 0.8996 |
| 7 | 0.3 | 103 | 8 | 15 | 96 | 0.9279 | 0.1351 | 0.8996 |
| 8 | 0.3 | 101 | 10 | 13 | 98 | 0.9099 | 0.1171 | 0.8978 |
| 4 | 0.3 | 104 | 7 | 17 | 94 | 0.9369 | 0.1532 | 0.8966 |
| 8 | 0.25 | 104 | 7 | 17 | 94 | 0.9369 | 0.1532 | 0.8966 |
| 5 | 0.35 | 101 | 10 | 14 | 97 | 0.9099 | 0.1261 | 0.8938 |
| 7 | 0.25 | 104 | 7 | 18 | 93 | 0.9369 | 0.1622 | 0.8927 |
| 6 | 0.35 | 99 | 12 | 12 | 99 | 0.8919 | 0.1081 | 0.8919 |

_(vs last committed results on main)_
**Branch:** `result_4.0.0-nobackground` | **Test dataset:** pyronear/pyro-dataset @ v4.0.0-corrected